### PR TITLE
Cinema updates

### DIFF
--- a/workshop/gamemodes/cinema_modded/gamemode/extensions/cl_draw.lua
+++ b/workshop/gamemodes/cinema_modded/gamemode/extensions/cl_draw.lua
@@ -9,7 +9,7 @@ local surface_SetMaterial = surface.SetMaterial
 local surface_DrawTexturedRect = surface.DrawTexturedRect
 
 local FPS_Cap = 30
-local FPS_Smoother = CreateClientConVar( "cinema_smoother", 0, true, false, "Make some videos smoother at the cost of FPS" )
+local FPS_Smoother = CreateClientConVar( "cinema_smoother", 1, true, false, "Make some videos smoother at the cost of FPS" )
 
 local function ChangeFrameCap()
 	local bool = FPS_Smoother:GetBool()

--- a/workshop/gamemodes/cinema_modded/gamemode/localization/brazilian_portuguese.lua
+++ b/workshop/gamemodes/cinema_modded/gamemode/localization/brazilian_portuguese.lua
@@ -85,7 +85,7 @@ LANG.Settings_HidePlayersTooltip = "Reduz a visiblidade dos jogadores dentro de 
 LANG.Settings_MuteFocusLabel     = "Silenciar áudio enquanto minimizado"
 LANG.Settings_MuteFocusTooltip   = "Silencia os vídeos enquanto o Garry's Mod estiver em segundo plano (por exemplo, ao minimizar)."
 LANG.Settings_SmoothVideoLabel	 = "Reproduzir vídeos suavemente"
-LANG.Settings_SmoothVideoTooltip = "Torna a reprodução de vídeos suave, mas reduz o desempenho do jogo."
+LANG.Settings_SmoothVideoTooltip = "Torna a reprodução de vídeos mais suave, mas reduz o desempenho do jogo."
 
 -- Video Services
 LANG.Service_EmbedDisabled      = "A incorporação do vídeo solicitado está desativada."

--- a/workshop/gamemodes/cinema_modded/gamemode/localization/brazilian_portuguese.lua
+++ b/workshop/gamemodes/cinema_modded/gamemode/localization/brazilian_portuguese.lua
@@ -33,12 +33,12 @@ LANG.Theater_UnlockedQueue          = C(ColHighlight,"%s",ColDefault," desbloque
 LANG.Theater_OwnerUseOnly           = "Somente o dono do teatro pode usar isso."
 LANG.Theater_PublicVideoLength      = "Solicitações feitas em teatros públicos são limitadas a %s segundo(s) de duração."
 LANG.Theater_PlayerVoteSkipped      = C(ColHighlight,"%s",ColDefault," votou para pular ",ColHighlight,"(%s/%s)",ColDefault,".")
-LANG.Theater_VideoAddedToQueue      = C(ColHighlight,"%s",ColDefault," foi adicionado(a) à fila.")
+LANG.Theater_VideoAddedToQueue      = C(ColHighlight,"%s",ColDefault," foi adicionado à fila.")
 
 -- Warnings
 -- cl_init.lua
 LANG.Warning_Unsupported_Line1  = "O mapa atual não tem suporte ao modo de jogo Cinema"
-LANG.Warning_Unsupported_Line2  = "Pressione F1 para abrir o mapa oficial na Oficina"
+LANG.Warning_Unsupported_Line2  = "Pressione F1 para abrir o mapa oficial na Oficina Steam"
 
 -- Queue
 -- modules/scoreboard/cl_queue.lua
@@ -74,16 +74,18 @@ LANG.Request_Url_Tooltip        = "Clique para solicitar um vídeo de um URL vá
 
 -- Scoreboard settings panel
 -- modules/scoreboard/cl_settings.lua
-LANG.Settings_Title             = "CONFIGURAÇÕES"
-LANG.Settings_ClickActivate     = "CLIQUE PARA ATIVAR O SEU MOUSE"
-LANG.Settings_VolumeLabel       = "Volume"
-LANG.Settings_VolumeTooltip     = "Use as teclas + e - para aumentar ou diminuir o volume."
-LANG.Settings_HDLabel           = "Reproduzir vídeos em HD"
-LANG.Settings_HDTooltip         = "Reproduz vídeos em HD sempre que possível."
-LANG.Settings_HidePlayersLabel  = "Ocultar jogadores em teatros"
+LANG.Settings_Title              = "CONFIGURAÇÕES"
+LANG.Settings_ClickActivate      = "CLIQUE PARA ATIVAR O SEU MOUSE"
+LANG.Settings_VolumeLabel        = "Volume"
+LANG.Settings_VolumeTooltip      = "Use as teclas + e - para aumentar ou diminuir o volume."
+LANG.Settings_HDLabel            = "Reproduzir vídeos em HD"
+LANG.Settings_HDTooltip          = "Reproduz vídeos em HD sempre que possível."
+LANG.Settings_HidePlayersLabel   = "Ocultar jogadores em teatros"
 LANG.Settings_HidePlayersTooltip = "Reduz a visiblidade dos jogadores dentro de teatros."
-LANG.Settings_MuteFocusLabel    = "Silenciar áudio enquanto minimizado"
-LANG.Settings_MuteFocusTooltip  = "Silencia os vídeos enquanto o Garry's Mod estiver em segundo plano (por exemplo, ao minimizar)."
+LANG.Settings_MuteFocusLabel     = "Silenciar áudio enquanto minimizado"
+LANG.Settings_MuteFocusTooltip   = "Silencia os vídeos enquanto o Garry's Mod estiver em segundo plano (por exemplo, ao minimizar)."
+LANG.Settings_SmoothVideoLabel	 = "Reproduzir vídeos suavemente"
+LANG.Settings_SmoothVideoTooltip = "Torna a reprodução de vídeos suave, mas reduz o desempenho do jogo."
 
 -- Video Services
 LANG.Service_EmbedDisabled      = "A incorporação do vídeo solicitado está desativada."

--- a/workshop/gamemodes/cinema_modded/gamemode/localization/english.lua
+++ b/workshop/gamemodes/cinema_modded/gamemode/localization/english.lua
@@ -84,7 +84,7 @@ LANG.Settings_HidePlayersLabel   = "Hide players in theaters"
 LANG.Settings_HidePlayersTooltip = "Reduces player visibility inside of theaters."
 LANG.Settings_MuteFocusLabel     = "Mute audio while alt-tabbed"
 LANG.Settings_MuteFocusTooltip   = "Mutes theater volume while Garry's Mod is out-of-focus (e.g. you alt-tabbed)."
-LANG.Settings_SmoothVideoLabel	 = "Smooth video playback"
+LANG.Settings_SmoothVideoLabel	 = "Smoother video playback"
 LANG.Settings_SmoothVideoTooltip = "Make some videos smoother at the cost of FPS."
 
 -- Video Services

--- a/workshop/gamemodes/cinema_modded/gamemode/localization/english.lua
+++ b/workshop/gamemodes/cinema_modded/gamemode/localization/english.lua
@@ -84,7 +84,7 @@ LANG.Settings_HidePlayersLabel   = "Hide players in theaters"
 LANG.Settings_HidePlayersTooltip = "Reduces player visibility inside of theaters."
 LANG.Settings_MuteFocusLabel     = "Mute audio while alt-tabbed"
 LANG.Settings_MuteFocusTooltip   = "Mutes theater volume while Garry's Mod is out-of-focus (e.g. you alt-tabbed)."
-LANG.Settings_SmoothVideoLabel	 = "Smoother video playback"
+LANG.Settings_SmoothVideoLabel	 = "Smooth video playback"
 LANG.Settings_SmoothVideoTooltip = "Make some videos smoother at the cost of FPS."
 
 -- Video Services

--- a/workshop/gamemodes/cinema_modded/gamemode/localization/english.lua
+++ b/workshop/gamemodes/cinema_modded/gamemode/localization/english.lua
@@ -38,7 +38,7 @@ LANG.Theater_VideoAddedToQueue      = C(ColHighlight,"%s",ColDefault," has been 
 -- Warnings
 -- cl_init.lua
 LANG.Warning_Unsupported_Line1  = "The current map is unsupported by the Cinema gamemode"
-LANG.Warning_Unsupported_Line2  = "Press F1 to open the official map on workshop"
+LANG.Warning_Unsupported_Line2  = "Press F1 to open the official map on the Steam Workshop"
 
 -- Queue
 -- modules/scoreboard/cl_queue.lua
@@ -74,16 +74,18 @@ LANG.Request_Url_Tooltip        = "Press to request a valid video URL.\nThe butt
 
 -- Scoreboard settings panel
 -- modules/scoreboard/cl_settings.lua
-LANG.Settings_Title             = "SETTINGS"
-LANG.Settings_ClickActivate     = "CLICK TO ACTIVATE YOUR MOUSE"
-LANG.Settings_VolumeLabel       = "Volume"
-LANG.Settings_VolumeTooltip     = "Use the +/- keys to increase/decrease volume."
-LANG.Settings_HDLabel           = "HD video playback"
-LANG.Settings_HDTooltip         = "Enables HD video playback for HD enabled videos."
-LANG.Settings_HidePlayersLabel  = "Hide players in theaters"
+LANG.Settings_Title              = "SETTINGS"
+LANG.Settings_ClickActivate      = "CLICK TO ACTIVATE YOUR MOUSE"
+LANG.Settings_VolumeLabel        = "Volume"
+LANG.Settings_VolumeTooltip      = "Use the + and - keys to increase/decrease volume."
+LANG.Settings_HDLabel            = "HD video playback"
+LANG.Settings_HDTooltip          = "Enables HD video playback for HD enabled videos."
+LANG.Settings_HidePlayersLabel   = "Hide players in theaters"
 LANG.Settings_HidePlayersTooltip = "Reduces player visibility inside of theaters."
-LANG.Settings_MuteFocusLabel    = "Mute audio while alt-tabbed"
-LANG.Settings_MuteFocusTooltip  = "Mutes theater volume while Garry's Mod is out-of-focus (e.g. you alt-tabbed)."
+LANG.Settings_MuteFocusLabel     = "Mute audio while alt-tabbed"
+LANG.Settings_MuteFocusTooltip   = "Mutes theater volume while Garry's Mod is out-of-focus (e.g. you alt-tabbed)."
+LANG.Settings_SmoothVideoLabel	 = "Smooth video playback"
+LANG.Settings_SmoothVideoTooltip = "Make some videos smoother at the cost of FPS."
 
 -- Video Services
 LANG.Service_EmbedDisabled      = "The requested video is embed disabled."

--- a/workshop/gamemodes/cinema_modded/gamemode/modules/scoreboard/cl_settings.lua
+++ b/workshop/gamemodes/cinema_modded/gamemode/modules/scoreboard/cl_settings.lua
@@ -126,8 +126,8 @@ function SETTINGS:Create()
 	HD.Label:SetTall(50)
 
 	-- Video Smoother
-	local VideoSmoother = self:NewSetting( "TheaterCheckBoxLabel", "Smooth Video Playback", "cinema_smoother" )
-	VideoSmoother:SetTooltip( "Make some videos smoother at the cost of FPS" )
+	local VideoSmoother = self:NewSetting( "TheaterCheckBoxLabel", T("Settings_SmoothVideoLabel"), "cinema_smoother" )
+	VideoSmoother:SetTooltip( T("Settings_SmoothVideoTooltip") )
 	VideoSmoother:AlignLeft( 16 )
 	VideoSmoother:AlignTop( self.TitleHeight + 64 )
 	VideoSmoother.Label:SetFont( "LabelFont" )

--- a/workshop/gamemodes/cinema_modded/gamemode/modules/theater/sh_commands.lua
+++ b/workshop/gamemodes/cinema_modded/gamemode/modules/theater/sh_commands.lua
@@ -4,10 +4,10 @@ CreateConVar( "cinema_queue_mode", 1, { FCVAR_ARCHIVE, FCVAR_DONTRECORD, FCVAR_R
 if CLIENT then
 
 	CreateClientConVar( "cinema_drawnames", 1, true, false )
-	CreateClientConVar( "cinema_volume", 25, true, false )
-	CreateClientConVar( "cinema_hd", 0, true, false )
+	CreateClientConVar( "cinema_volume", 50, true, false )
+	CreateClientConVar( "cinema_hd", 1, true, false )
 	CreateClientConVar( "cinema_cc", 0, true, false )
-	CreateClientConVar( "cinema_resolution", 720, true, false )
+	CreateClientConVar( "cinema_resolution", 1080, true, false )
 	local MuteNoFocus = CreateClientConVar( "cinema_mute_nofocus", 1, true, false )
 	local ScrollAmount = CreateClientConVar( "cinema_scrollamount", 60, true, false )
 	local HidePlayers = CreateClientConVar( "cinema_hideplayers", 0, true, false )


### PR DESCRIPTION
This pull request:

- change some of the Cinema's default values for cvars. These changes include:
`cinema_smoother` : `0` -> `1`
`cinema_volume` : `25` -> `50`
`cinema_hd` : `0` -> `1`
`cinema_resolution` : `720` -> `1080`

The reason behind these changes is that I think the gamemode should choose to set a good quality by default, because as Garry's Mod is a old game, it is likely that an immense majority of people have a relatively good PC for play videos on high settings. What I think is: let's put the default on the high settings, and if anyone has problems, they can personally change their settings. It is possible that many people use Cinema with the default settings, and watch videos in low quality when they could be with a high quality.

About the change in volume, it's because "25" is a very low value and from what I see people who have just entered the Cinema always tend to turn it up a little. So I decided to go for "50" as it is literally the best balance between low and high.

- makes the "Smooth video playback" string translatable;

- changes some strings in the English and Brazilian Portuguese language. Most of the changes to the localization files were to add a space and maintain conformity, there are no differences in the strings apart from a few notable differences from the GitHub changelog itself and the addition of the Smooth video playback strings.

That's all. None of the changes have been tested, but they should work flawlessly.