### PR TITLE
Update localizations

### DIFF
--- a/workshop/gamemodes/cinema_modded/gamemode/localization/brazilian_portuguese.lua
+++ b/workshop/gamemodes/cinema_modded/gamemode/localization/brazilian_portuguese.lua
@@ -1,7 +1,7 @@
 -- Basic information
 LANG.Name       = "Português (Brasil)" -- Native name for language
-LANG.Id         = "pt-BR"      -- Find corresponding ID in garrysmod/resource/localization
-LANG.Author     = "Tiagoquix"        -- Chain authors if necessary (e.g. "Sam, MacDGuy, Foohy")
+LANG.Id         = "pt-BR"              -- Find corresponding ID in garrysmod/resource/localization
+LANG.Author     = "Tiagoquix"          -- Chain authors if necessary (e.g. "Sam, MacDGuy, Foohy")
 
 -- Common
 LANG.Cinema                     = "CINEMA"
@@ -31,13 +31,13 @@ LANG.Theater_OwnerLockedQueue       = "O dono do teatro bloqueou a fila."
 LANG.Theater_LockedQueue            = C(ColHighlight,"%s",ColDefault," bloqueou a fila do teatro.")
 LANG.Theater_UnlockedQueue          = C(ColHighlight,"%s",ColDefault," desbloqueou a fila do teatro.")
 LANG.Theater_OwnerUseOnly           = "Somente o dono do teatro pode usar isso."
-LANG.Theater_PublicVideoLength      = "Solicitações feitas em teatros públicos são limitadas a %s segundo(s) de duração."
+LANG.Theater_PublicVideoLength      = "Solicitações feitas em teatros públicos são limitadas a %s segundos de duração."
 LANG.Theater_PlayerVoteSkipped      = C(ColHighlight,"%s",ColDefault," votou para pular ",ColHighlight,"(%s/%s)",ColDefault,".")
 LANG.Theater_VideoAddedToQueue      = C(ColHighlight,"%s",ColDefault," foi adicionado à fila.")
 
 -- Warnings
 -- cl_init.lua
-LANG.Warning_Unsupported_Line1  = "O mapa atual não tem suporte ao modo de jogo Cinema"
+LANG.Warning_Unsupported_Line1  = "O mapa atual é incompatível com o modo de jogo Cinema"
 LANG.Warning_Unsupported_Line2  = "Pressione F1 para abrir o mapa oficial na Oficina Steam"
 
 -- Queue

--- a/workshop/gamemodes/cinema_modded/gamemode/localization/english.lua
+++ b/workshop/gamemodes/cinema_modded/gamemode/localization/english.lua
@@ -1,7 +1,7 @@
 -- Basic information
-LANG.Name       = "English" -- Native name for language
-LANG.Id         = "en"      -- Find corresponding ID in garrysmod/resource/localization
-LANG.Author     = ""        -- Chain authors if necessary (e.g. "Sam, MacDGuy, Foohy")
+LANG.Name       = "English"    -- Native name for language
+LANG.Id         = "en"         -- Find corresponding ID in garrysmod/resource/localization
+LANG.Author     = "FarukGamer" -- Chain authors if necessary (e.g. "Sam, MacDGuy, Foohy")
 
 -- Common
 LANG.Cinema                     = "CINEMA"
@@ -17,7 +17,7 @@ LANG.Set                        = "Set"
 -- modules/theater/cl_init.lua
 -- modules/theater/sh_commands.lua
 -- modules/theater/sh_theater.lua
-LANG.Theater_VideoRequestedBy       = C("Current video requested by ",ColHighlight,"%s",ColDefault,".")
+LANG.Theater_VideoRequestedBy       = C("The current video was requested by ",ColHighlight,"%s",ColDefault,".")
 LANG.Theater_InvalidRequest         = "Invalid video request."
 LANG.Theater_AlreadyQueued          = "The requested video is already in the queue."
 LANG.Theater_ProcessingRequest      = C("Processing ",ColHighlight,"%s",ColDefault," request...")
@@ -31,7 +31,7 @@ LANG.Theater_OwnerLockedQueue       = "The owner of the theater has locked the q
 LANG.Theater_LockedQueue            = C(ColHighlight,"%s",ColDefault," has locked the theater queue.")
 LANG.Theater_UnlockedQueue          = C(ColHighlight,"%s",ColDefault," has unlocked the theater queue.")
 LANG.Theater_OwnerUseOnly           = "Only the theater owner can use that."
-LANG.Theater_PublicVideoLength      = "Public theater requests are limited to %s second(s) in length."
+LANG.Theater_PublicVideoLength      = "Public theater requests are limited to %s seconds in length."
 LANG.Theater_PlayerVoteSkipped      = C(ColHighlight,"%s",ColDefault," has voted to skip ",ColHighlight,"(%s/%s)",ColDefault,".")
 LANG.Theater_VideoAddedToQueue      = C(ColHighlight,"%s",ColDefault," has been added to the queue.")
 
@@ -43,10 +43,10 @@ LANG.Warning_Unsupported_Line2  = "Press F1 to open the official map on the Stea
 -- Queue
 -- modules/scoreboard/cl_queue.lua
 LANG.Queue_Title                = "QUEUE"
-LANG.Request_Video              = "Request Video"
-LANG.Vote_Skip                  = "Vote Skip"
-LANG.Toggle_Fullscreen          = "Toggle Fullscreen"
-LANG.Refresh_Theater            = "Refresh Theater"
+LANG.Request_Video              = "Request video"
+LANG.Vote_Skip                  = "Vote to skip"
+LANG.Toggle_Fullscreen          = "Toggle fullscreen"
+LANG.Refresh_Theater            = "Refresh theater"
 
 -- Theater controls
 -- modules/scoreboard/cl_admin.lua
@@ -55,8 +55,8 @@ LANG.Theater_Owner              = "OWNER"
 LANG.Theater_Skip               = "Skip"
 LANG.Theater_Seek               = "Seek"
 LANG.Theater_Reset              = "Reset"
-LANG.Theater_ChangeName         = "Change Name"
-LANG.Theater_QueueLock          = "Toggle Queue Lock"
+LANG.Theater_ChangeName         = "Change name"
+LANG.Theater_QueueLock          = "Toggle queue lock"
 LANG.Theater_SeekQuery          = "HH:MM:SS or number of seconds (e.g. 1:30:00 or 5400)"
 
 -- Theater list


### PR DESCRIPTION
This improves the English and Brazilian Portuguese localizations.

Primarily:

- removes the "(s)" in "second(s)" (no one sets the cap to 1 second);
- changes `LANG.Warning_Unsupported_Line1` (portuguese only);
- removes multiple instances of Unnecessary Capital Letters;
- misc. changes.