### PR TITLE
Round duration of YouTube videos

### DIFF
--- a/public/youtube_meta.html
+++ b/public/youtube_meta.html
@@ -89,7 +89,7 @@
 							const metadata = {
 								title: videoData.title,
 								isLive: videoData.isLive,
-								duration: player.getDuration(),
+								duration: Math.round(player.getDuration()),
 							};
 
 							console.log("METADATA:" + JSON.stringify(metadata));


### PR DESCRIPTION
Fixes YouTube videos having their duration listed with milliseconds