### PR TITLE
Improve compatibility with Sandbox mode when `Enable Sandbox` is enabled

### DIFF
--- a/cinema_modded/gamemode/cl_init.lua
+++ b/cinema_modded/gamemode/cl_init.lua
@@ -38,14 +38,17 @@ end )
 	HUD Elements to hide
 --]]
 GM.HUDToHide = {
-	"CHudHealth",
-	"CHudSuitPower",
-	"CHudBattery",
-	"CHudCrosshair",
-	"CHudAmmo",
-	"CHudSecondaryAmmo",
-	"CHudZoom"
+    ["CHudHealth"] = true,
+    ["CHudSuitPower"] = true,
+    ["CHudBattery"] = true,
+    ["CHudCrosshair"] = true,
+    ["CHudAmmo"] = true,
+    ["CHudSecondaryAmmo"] = true,
+    ["CHudZoom"] = true
 }
+
+local LocalPlayer = LocalPlayer
+local IsValid = IsValid
 
 --[[---------------------------------------------------------
    Name: gamemode:HUDShouldDraw( name )
@@ -59,16 +62,22 @@ function GM:HUDShouldDraw( name )
 
 		local wep = ply:GetActiveWeapon()
 
-		if (wep and wep:IsValid() and wep.HUDShouldDraw ~= nil) then
+		if ( IsValid( wep ) and wep.HUDShouldDraw ) then
 
-			return wep.HUDShouldDraw( wep, name )
+			return wep:HUDShouldDraw( name )
+
+		end
+
+		-- If Sandbox is loaded, draw HUD outside of the theater.
+		if ( self.IsSandboxDerived and not ply:InTheater() ) then
+
+			return true
 
 		end
 
 	end
 
-	return not table.HasValue(self.HUDToHide, name)
-
+	return not self.HUDToHide[name]
 end
 
 --[[---------------------------------------------------------

--- a/cinema_modded/gamemode/cl_init.lua
+++ b/cinema_modded/gamemode/cl_init.lua
@@ -38,13 +38,13 @@ end )
 	HUD Elements to hide
 --]]
 GM.HUDToHide = {
-    ["CHudHealth"] = true,
-    ["CHudSuitPower"] = true,
-    ["CHudBattery"] = true,
-    ["CHudCrosshair"] = true,
-    ["CHudAmmo"] = true,
-    ["CHudSecondaryAmmo"] = true,
-    ["CHudZoom"] = true
+	["CHudHealth"] = true,
+	["CHudSuitPower"] = true,
+	["CHudBattery"] = true,
+	["CHudCrosshair"] = true,
+	["CHudAmmo"] = true,
+	["CHudSecondaryAmmo"] = true,
+	["CHudZoom"] = true
 }
 
 local LocalPlayer = LocalPlayer

--- a/cinema_modded/gamemode/player.lua
+++ b/cinema_modded/gamemode/player.lua
@@ -168,9 +168,20 @@ end
    Name: gamemode:GetFallDamage()
 		return amount of damage to do due to fall
 -----------------------------------------------------------]]
+local mp_falldamage = GetConVar( "mp_falldamage" )
+
 function GM:GetFallDamage( ply, flFallSpeed )
 
-	return 0
+	if not self.IsSandboxDerived then
+		return 0
+	end
+
+	-- From "gamemodes/base/gamemode/player.lua#765"
+	if ( mp_falldamage:GetBool() ) then -- realistic fall damage is on
+		return ( flFallSpeed - 526.5 ) * ( 100 / 396 ) -- the Source SDK value
+	end
+
+	return 10
 
 end
 

--- a/cinema_modded/gamemode/player_shd.lua
+++ b/cinema_modded/gamemode/player_shd.lua
@@ -56,6 +56,9 @@ end
 -----------------------------------------------------------]]
 function GM:PlayerNoClip( pl, on )
 
+	-- Allow admin to noclip
+	if pl:IsAdmin() then return true end
+
 	if GetConVar( "sv_cheats" ):GetInt() > 0 then return true end
 
 	-- Allow noclip if we're in single player

--- a/cinema_modded/gamemode/shared.lua
+++ b/cinema_modded/gamemode/shared.lua
@@ -53,9 +53,12 @@ loadMap(true) -- Backward compatibility
 --[[---------------------------------------------------------
 	 Name: gamemode:PlayerShouldTakeDamage
 	 Return true if this player should take damage from this attacker
+	 Cinema: If Sandbox is loaded, apply Sandbox rules instead.
 -----------------------------------------------------------]]
-function GM:PlayerShouldTakeDamage( ply, attacker )
-	return false
+if not Cvar_DeriveSbox:GetBool() then
+	function GM:PlayerShouldTakeDamage( ply, attacker )
+		return false
+	end
 end
 
 --[[---------------------------------------------------------


### PR DESCRIPTION
Not much stuff, mainly is making default HUD can be shown and player can be killed.

- Allow admin to noclip anytime they want. Some maps contain noclip-only theaters (admin theater), this will make them accessable.
- Apply micro optimisation to **`HUDShouldDraw`** hook, should gain couple milliseconds performance because it's a very frequent calls.

When **`Enable Sandbox`** is enabled:
- Allow showing default HUD when player is outside of the theaters. If player enters theater HUD will be hidden.
- Allow player taking damage from world, npc and other players, server admins can use **`sbox_godmode 1`** to make player invincible again.