### PR TITLE
Make text chat no longer be "Counterintuitive" & Localization logic fixes

### DIFF
--- a/cinema_modded/entities/entities/theater_door/sh_init.lua
+++ b/cinema_modded/entities/entities/theater_door/sh_init.lua
@@ -5,3 +5,5 @@ ENT.AutomaticFrameAdvance = true
 ENT.DelayTime = 0.75 --how long until the screen begins to fade
 ENT.FadeTime = 0.80 --how long it takes to fade completely
 ENT.WaitTime = 0.10 --period for it to stay completely black
+
+ENT.PhysgunDisabled = true -- Physgun cannot pick up this entity

--- a/cinema_modded/gamemode/i18n/init.lua
+++ b/cinema_modded/gamemode/i18n/init.lua
@@ -23,7 +23,7 @@ end
 if SERVER then return end
 
 local DefaultId = "en"
-local CurrentId = GetConVar("gmod_language"):GetString()
+local CurrentId = GetConVar("gmod_language"):GetString():lower()
 
 local I18nColors = include("colors.lua")
 local TranslationSchema = include("schema.lua")
@@ -174,6 +174,7 @@ end
 -- Language change callback
 cvars.AddChangeCallback("gmod_language", function(_, value_old, value_new)
 	if not CLIENT then return end
+	value_new = value_new:lower()
 	CurrentId = Languages[value_new] and value_new or DefaultId
 	RunConsoleCommand("cinema_langupdate")
 end)

--- a/cinema_modded/gamemode/player.lua
+++ b/cinema_modded/gamemode/player.lua
@@ -192,18 +192,16 @@ end
 function GM:PlayerCanSeePlayersChat( strText, bTeamOnly, pListener, pSpeaker )
 
 	-- Console 'say' command
-	if not IsValid(pSpeaker) then
+	if not IsValid( pSpeaker ) then
 		return true
 	end
 
-	-- Local chat functions as global chat in Cinema
+	-- Team chat will only boardcast to players in the same location
 	if bTeamOnly then
-		return true
+		return pSpeaker:GetLocation() == pListener:GetLocation()
 	end
 
-	-- Players should only receive chat messages from users in the same
-	-- theater if it wasn't global.
-	return pSpeaker:GetTheater() == pListener:GetTheater()
+	return true
 
 end
 

--- a/cinema_modded/gamemode/player_shd.lua
+++ b/cinema_modded/gamemode/player_shd.lua
@@ -29,9 +29,9 @@ function GM:OnPlayerChat( player, strText, bTeamOnly, bPlayerIsDead )
 		table.insert( tab, "*DEAD* " )
 	end
 
-	if ( bTeamOnly ) then
+	if ( bTeamOnly and IsValid(player) ) then
 		table.insert( tab, Color( 123, 32, 29 ) )
-		table.insert( tab, "(GLOBAL) " )
+		table.insert( tab, "[" .. player:GetLocationName() .. "] " )
 	end
 
 	if ( IsValid( player ) ) then

--- a/cinema_modded/gamemode/shared.lua
+++ b/cinema_modded/gamemode/shared.lua
@@ -5,10 +5,9 @@ GM.Website 		= "www.pixeltailgames.com"
 GM.TeamBased 	= false
 
 -- Enable sandbox functionalities
-local Cvar_DeriveSbox = CreateConVar("cinema_enable_sandbox", "0", {FCVAR_NOTIFY, FCVAR_REPLICATED,
-FCVAR_REPLICATED, FCVAR_LUA_SERVER, FCVAR_ARCHIVE}, "NEEDS SERVER RESTART!")
+local Cvar_DeriveSbox = GetConVar("cinema_enable_sandbox") -- This command is created by GMod itself (defined in cinema_modded.txt).
 
-if not GM.IsSandboxDerived and Cvar_DeriveSbox:GetBool() then
+if ( !GM.IsSandboxDerived and Cvar_DeriveSbox:GetBool() ) then
 	DeriveGamemode( "sandbox" )
 end
 


### PR DESCRIPTION
I've been thinking about why the text chat is so "counterintuitive", since at least 70% of players are used to talking with their "Y" key instead of "U". However, this gamemode chooses the opposite: the Y key sends chat only within the same theater, while the U key is global chat (the default game chat behavior). The normal chat doesn't give a clear hint about its limited range, which confuses players the first time.
So I want to correct this behavior, restoring normal chat to the default behavior, and team chat now works in a limited range. Now when a player chats using team chat (U key or `say_team` command), only players within the same location (shown on the TAB screen) will see the message. The location will be shown to the left of the player's name, giving a clear hint that "this is a chat message that can only be seen here".

I also fixed a rare issue that only affects fresh GMod players in special regions where the "gmod_language" variable contains uppercase characters. Cinema uses all lowercase to match language codes, so those players always saw English localization instead of their own language.
Affected regions: `en-PT`, `es-ES`, `pt-BR`, `pt-PT`, `sv-SE`, `zh-CN`, `zh-TW`.

Changelog:
- Made physgun unable to pick up theater doors (`theater_door` entity), preventing trolling players from breaking the map.
- Made Cinema always read the "gmod_language" value as lowercase, fixing the issue mentioned above.
- Made text chat less counterintuitive as described above.
- Minor code correction for the `cinema_enable_sandbox` command and aligned the code format (does not actually change anything, only for better readability).